### PR TITLE
Improve UI to make the app more native-look

### DIFF
--- a/HomeConMenu/Resources/Localizable.xcstrings
+++ b/HomeConMenu/Resources/Localizable.xcstrings
@@ -179,7 +179,7 @@
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "何もありません。"
+            "value" : "何もありません"
           }
         }
       }
@@ -245,7 +245,7 @@
         }
       }
     },
-    "Remove all" : {
+    "Remove All" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {

--- a/HomeConMenu/Resources/Localizable.xcstrings
+++ b/HomeConMenu/Resources/Localizable.xcstrings
@@ -21,12 +21,12 @@
         }
       }
     },
-    "Allow HomeConMenu to access HomeKit in System Preferences." : {
+    "Allow HomeConMenu to access HomeKit in System Settings." : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "システム環境設定を使ってHomeConMenuにHomeKitへのアクセス権を設定してください。"
+            "value" : "システム設定を使ってHomeConMenuにHomeKitへのアクセス権を設定してください。"
           }
         }
       }
@@ -205,33 +205,12 @@
         }
       }
     },
-    "Open System Preferences" : {
+    "Open System Settings" : {
       "localizations" : {
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "システム環境設定を開く"
-          }
-        }
-      }
-    },
-    "Preferences" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "環境設定"
-          }
-        }
-      }
-    },
-    "Preferences…" : {
-      "localizations" : {
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "環境設定…"
+            "value" : "システム設定を開く"
           }
         }
       }
@@ -282,6 +261,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "シーン"
+          }
+        }
+      }
+    },
+    "Settings…" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定…"
           }
         }
       }

--- a/HomeConMenu/Resources/ja.lproj/Acknowledgments.html
+++ b/HomeConMenu/Resources/ja.lproj/Acknowledgments.html
@@ -16,7 +16,7 @@
 <section class="CotEditor">
 <h3>CotEditor</h3>
 <p><a href="https://github.com/coteditor/CotEditor">https://github.com/coteditor/CotEditor</a></p>
-<p>環境設定のビューは，CotEditorのコードを参考にしています．</p>
+<p>設定のビューは，CotEditorのコードを参考にしています．</p>
 
 <details>
 <summary>Apache license</summary>

--- a/HomeConMenu/Resources/ja.lproj/Acknowledgments.html
+++ b/HomeConMenu/Resources/ja.lproj/Acknowledgments.html
@@ -16,7 +16,7 @@
 <section class="CotEditor">
 <h3>CotEditor</h3>
 <p><a href="https://github.com/coteditor/CotEditor">https://github.com/coteditor/CotEditor</a></p>
-<p>設定のビューは，CotEditorのコードを参考にしています．</p>
+<p>設定のビューは、CotEditorのコードを参考にしています。</p>
 
 <details>
 <summary>Apache license</summary>

--- a/HomeConMenu/macOS/Base.lproj/LaunchView.xib
+++ b/HomeConMenu/macOS/Base.lproj/LaunchView.xib
@@ -82,7 +82,7 @@
                             <constraints>
                                 <constraint firstAttribute="width" constant="400" id="IJp-fg-igi"/>
                             </constraints>
-                            <textFieldCell key="cell" alignment="left" title="To use this application, go to Security &amp; Privacy settings in System Preferences and allow HomeConMenu to access HomeKit." id="wrg-Q9-ZTw">
+                            <textFieldCell key="cell" alignment="left" title="To use this application, go to Security &amp; Privacy settings in System Settings and allow HomeConMenu to access HomeKit." id="wrg-Q9-ZTw">
                                 <font key="font" metaFont="system"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/HomeConMenu/macOS/MacOSController.swift
+++ b/HomeConMenu/macOS/MacOSController.swift
@@ -64,11 +64,11 @@ class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
     func openHomeKitAuthenticationError() -> Bool {
         let alert = NSAlert()
         alert.messageText = NSLocalizedString("Failed to access HomeKit because of your privacy settings.", comment: "")
-        alert.informativeText = NSLocalizedString("Allow HomeConMenu to access HomeKit in System Preferences.", comment:"")
+        alert.informativeText = NSLocalizedString("Allow HomeConMenu to access HomeKit in System Settings.", comment:"")
         alert.alertStyle = .informational
 
         alert.addButton(withTitle: "OK")
-        alert.addButton(withTitle: NSLocalizedString("Open System Preferences", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Open System Settings", comment: ""))
         
         let ret = alert.runModal()
         switch ret {
@@ -273,7 +273,7 @@ class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
         mainMenu.addItem(abouItem)
         
         let prefItem = NSMenuItem()
-        prefItem.title = NSLocalizedString("Preferences…", comment: "")
+        prefItem.title = NSLocalizedString("Settings…", comment: "")
         prefItem.action = #selector(MacOSController.preferences(sender:))
         prefItem.target = self
         mainMenu.addItem(prefItem)

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/DonationPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/DonationPane.xib
@@ -35,7 +35,7 @@
                     <rect key="frame" x="284" y="82" width="32" height="32"/>
                 </progressIndicator>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="l9J-m1-0ba">
-                    <rect key="frame" x="20" y="20" width="559" height="156"/>
+                    <rect key="frame" x="20" y="30" width="559" height="146"/>
                 </stackView>
             </subviews>
             <constraints>
@@ -44,7 +44,7 @@
                 <constraint firstItem="x8C-ah-MeJ" firstAttribute="centerY" secondItem="ObF-C9-2Jk" secondAttribute="centerY" id="PMr-jw-ug1"/>
                 <constraint firstItem="l9J-m1-0ba" firstAttribute="leading" secondItem="ObF-C9-2Jk" secondAttribute="leading" constant="20" symbolic="YES" id="UW3-bj-2jY"/>
                 <constraint firstItem="Ycc-WL-E1J" firstAttribute="centerY" secondItem="ObF-C9-2Jk" secondAttribute="centerY" id="iGZ-k0-Xxf"/>
-                <constraint firstAttribute="bottom" secondItem="l9J-m1-0ba" secondAttribute="bottom" constant="20" symbolic="YES" id="p17-QZ-Vf2"/>
+                <constraint firstAttribute="bottom" secondItem="l9J-m1-0ba" secondAttribute="bottom" constant="30" id="p17-QZ-Vf2"/>
                 <constraint firstItem="Ycc-WL-E1J" firstAttribute="centerX" secondItem="ObF-C9-2Jk" secondAttribute="centerX" id="wW6-bg-IkV"/>
                 <constraint firstItem="x8C-ah-MeJ" firstAttribute="centerX" secondItem="ObF-C9-2Jk" secondAttribute="centerX" id="zqw-S4-QvR"/>
             </constraints>

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/GeneralPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/GeneralPane.xib
@@ -17,15 +17,14 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="286"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="601" height="240"/>
             <subviews>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="gRy-QW-fFD">
-                    <rect key="frame" x="32" y="0.0" width="536" height="286"/>
+                    <rect key="frame" x="37" y="0.0" width="527" height="240"/>
                     <subviews>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="knm-6J-dE0">
-                            <rect key="frame" x="31" y="148" width="70" height="16"/>
+                            <rect key="frame" x="31" y="148" width="60" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="HomeKit:" id="qzf-db-N8L">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -33,7 +32,7 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xha-OB-N1o">
-                            <rect key="frame" x="105" y="193" width="175" height="18"/>
+                            <rect key="frame" x="95" y="175" width="175" height="18"/>
                             <buttonCell key="cell" type="check" title="Show welcome message" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3Vt-E6-mDP">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -43,7 +42,7 @@
                             </connections>
                         </button>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y78-4e-KS2">
-                            <rect key="frame" x="18" y="194" width="83" height="16"/>
+                            <rect key="frame" x="18" y="176" width="73" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="On startup:" id="LVi-Yv-OrG">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -51,7 +50,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m3o-HT-Jvx">
-                            <rect key="frame" x="42" y="240" width="59" height="16"/>
+                            <rect key="frame" x="32" y="204" width="59" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="On login:" id="cCW-5N-XTR">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -59,7 +58,7 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="54O-O0-p2M">
-                            <rect key="frame" x="105" y="51" width="192" height="18"/>
+                            <rect key="frame" x="95" y="51" width="192" height="18"/>
                             <buttonCell key="cell" type="check" title="Display duplicated services" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stD-Gu-pED">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -69,10 +68,9 @@
                             </connections>
                         </button>
                         <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BWw-hH-XU3">
-                            <rect key="frame" x="125" y="98" width="393" height="42"/>
+                            <rect key="frame" x="115" y="98" width="394" height="42"/>
                             <constraints>
-                                <constraint firstAttribute="height" relation="lessThanOrEqual" constant="60" id="6Hc-Eo-usV"/>
-                                <constraint firstAttribute="width" constant="389" id="gDY-P9-jYG"/>
+                                <constraint firstAttribute="width" constant="390" id="gDY-P9-jYG"/>
                             </constraints>
                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" id="rND-QH-1vd">
                                 <font key="font" metaFont="smallSystem"/>
@@ -82,7 +80,7 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NU1-eW-0mB">
-                            <rect key="frame" x="105" y="147" width="184" height="18"/>
+                            <rect key="frame" x="95" y="147" width="184" height="18"/>
                             <buttonCell key="cell" type="check" title="Display &quot;Reload&quot; on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tHP-Rs-wID">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -92,7 +90,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="M2E-B5-fTf">
-                            <rect key="frame" x="105" y="29" width="97" height="18"/>
+                            <rect key="frame" x="95" y="29" width="97" height="18"/>
                             <buttonCell key="cell" type="check" title="Use scenes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xwK-VA-rRD">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -102,7 +100,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E6F-8T-u6X">
-                            <rect key="frame" x="105" y="73" width="241" height="18"/>
+                            <rect key="frame" x="95" y="73" width="241" height="18"/>
                             <buttonCell key="cell" type="check" title="Display &quot;Open Home.app&quot; on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0bf-nM-uXN">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -112,7 +110,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JU2-GR-rTo">
-                            <rect key="frame" x="105" y="239" width="155" height="18"/>
+                            <rect key="frame" x="95" y="203" width="155" height="18"/>
                             <buttonCell key="cell" type="check" title="Launch automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Pq4-7v-AnZ">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -124,44 +122,44 @@
                     </subviews>
                     <constraints>
                         <constraint firstItem="m3o-HT-Jvx" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gRy-QW-fFD" secondAttribute="leading" constant="20" symbolic="YES" id="1YU-CR-i0I"/>
-                        <constraint firstItem="NU1-eW-0mB" firstAttribute="centerY" secondItem="knm-6J-dE0" secondAttribute="centerY" id="1nT-VB-e5w"/>
+                        <constraint firstItem="NU1-eW-0mB" firstAttribute="firstBaseline" secondItem="knm-6J-dE0" secondAttribute="firstBaseline" id="1nT-VB-e5w"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Xha-OB-N1o" secondAttribute="trailing" constant="20" symbolic="YES" id="373-MR-H92"/>
                         <constraint firstItem="54O-O0-p2M" firstAttribute="leading" secondItem="E6F-8T-u6X" secondAttribute="leading" id="3QM-qQ-k36"/>
                         <constraint firstItem="E6F-8T-u6X" firstAttribute="top" secondItem="BWw-hH-XU3" secondAttribute="bottom" constant="8" symbolic="YES" id="3yN-Zm-Tw7"/>
-                        <constraint firstItem="knm-6J-dE0" firstAttribute="leading" secondItem="gRy-QW-fFD" secondAttribute="leading" constant="33" id="4rj-Pd-DBy"/>
+                        <constraint firstItem="knm-6J-dE0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gRy-QW-fFD" secondAttribute="leading" constant="20" symbolic="YES" id="4rj-Pd-DBy"/>
                         <constraint firstItem="54O-O0-p2M" firstAttribute="top" secondItem="E6F-8T-u6X" secondAttribute="bottom" constant="6" symbolic="YES" id="6Yf-MZ-guq"/>
                         <constraint firstAttribute="trailing" secondItem="BWw-hH-XU3" secondAttribute="trailing" constant="20" symbolic="YES" id="6cl-92-XzR"/>
                         <constraint firstItem="JU2-GR-rTo" firstAttribute="leading" secondItem="m3o-HT-Jvx" secondAttribute="trailing" constant="8" symbolic="YES" id="CIt-pS-A7d"/>
-                        <constraint firstItem="JU2-GR-rTo" firstAttribute="centerY" secondItem="m3o-HT-Jvx" secondAttribute="centerY" id="E8b-dj-p7Y"/>
+                        <constraint firstItem="JU2-GR-rTo" firstAttribute="firstBaseline" secondItem="m3o-HT-Jvx" secondAttribute="firstBaseline" id="E8b-dj-p7Y"/>
                         <constraint firstItem="knm-6J-dE0" firstAttribute="trailing" secondItem="y78-4e-KS2" secondAttribute="trailing" id="GKb-mQ-xyh"/>
-                        <constraint firstItem="knm-6J-dE0" firstAttribute="top" secondItem="y78-4e-KS2" secondAttribute="bottom" constant="30" id="HsO-bi-OoA"/>
-                        <constraint firstAttribute="bottom" relation="lessThanOrEqual" secondItem="M2E-B5-fTf" secondAttribute="bottom" constant="30" id="IiS-FH-qAU"/>
-                        <constraint firstAttribute="trailing" secondItem="JU2-GR-rTo" secondAttribute="trailing" constant="276" id="MWJ-k7-KjY"/>
+                        <constraint firstItem="knm-6J-dE0" firstAttribute="top" secondItem="y78-4e-KS2" secondAttribute="bottom" constant="12" id="HsO-bi-OoA"/>
+                        <constraint firstAttribute="bottom" secondItem="M2E-B5-fTf" secondAttribute="bottom" constant="30" id="IiS-FH-qAU"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JU2-GR-rTo" secondAttribute="trailing" constant="20" symbolic="YES" id="MWJ-k7-KjY"/>
                         <constraint firstItem="NU1-eW-0mB" firstAttribute="leading" secondItem="Xha-OB-N1o" secondAttribute="leading" id="O74-t0-NOV"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="E6F-8T-u6X" secondAttribute="trailing" constant="20" symbolic="YES" id="PJu-f1-GCA"/>
-                        <constraint firstItem="y78-4e-KS2" firstAttribute="leading" secondItem="gRy-QW-fFD" secondAttribute="leading" constant="20" symbolic="YES" id="VWv-PA-sEj"/>
+                        <constraint firstItem="y78-4e-KS2" firstAttribute="leading" secondItem="gRy-QW-fFD" secondAttribute="leading" priority="750" constant="20" symbolic="YES" id="VWv-PA-sEj"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="M2E-B5-fTf" secondAttribute="trailing" constant="20" symbolic="YES" id="YHg-xo-22h"/>
                         <constraint firstItem="y78-4e-KS2" firstAttribute="trailing" secondItem="m3o-HT-Jvx" secondAttribute="trailing" id="e89-eh-Ac5"/>
                         <constraint firstItem="BWw-hH-XU3" firstAttribute="top" secondItem="NU1-eW-0mB" secondAttribute="bottom" constant="8" symbolic="YES" id="gI2-ty-eul"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="54O-O0-p2M" secondAttribute="trailing" constant="20" symbolic="YES" id="hFq-F8-XK6"/>
                         <constraint firstItem="M2E-B5-fTf" firstAttribute="top" secondItem="54O-O0-p2M" secondAttribute="bottom" constant="6" symbolic="YES" id="hLV-Kk-Kuc"/>
-                        <constraint firstItem="Xha-OB-N1o" firstAttribute="centerY" secondItem="y78-4e-KS2" secondAttribute="centerY" id="i8p-1u-ThK"/>
+                        <constraint firstItem="Xha-OB-N1o" firstAttribute="firstBaseline" secondItem="y78-4e-KS2" secondAttribute="firstBaseline" id="i8p-1u-ThK"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="NU1-eW-0mB" secondAttribute="trailing" constant="20" symbolic="YES" id="mBo-P6-aVb"/>
                         <constraint firstItem="Xha-OB-N1o" firstAttribute="leading" secondItem="y78-4e-KS2" secondAttribute="trailing" constant="8" symbolic="YES" id="msy-6V-ywe"/>
-                        <constraint firstItem="m3o-HT-Jvx" firstAttribute="top" secondItem="gRy-QW-fFD" secondAttribute="top" constant="30" id="p6b-wb-oSM"/>
+                        <constraint firstItem="m3o-HT-Jvx" firstAttribute="top" secondItem="gRy-QW-fFD" secondAttribute="top" constant="20" symbolic="YES" id="p6b-wb-oSM"/>
                         <constraint firstItem="BWw-hH-XU3" firstAttribute="leading" secondItem="NU1-eW-0mB" secondAttribute="leading" constant="20" id="qMS-7h-L7P"/>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="286" id="r28-SV-xvo"/>
-                        <constraint firstItem="y78-4e-KS2" firstAttribute="top" secondItem="m3o-HT-Jvx" secondAttribute="bottom" constant="30" id="tA7-hQ-5Y5"/>
+                        <constraint firstItem="y78-4e-KS2" firstAttribute="top" secondItem="m3o-HT-Jvx" secondAttribute="bottom" constant="12" id="tA7-hQ-5Y5"/>
                         <constraint firstItem="M2E-B5-fTf" firstAttribute="leading" secondItem="54O-O0-p2M" secondAttribute="leading" id="wEu-mf-HhP"/>
                         <constraint firstItem="E6F-8T-u6X" firstAttribute="leading" secondItem="NU1-eW-0mB" secondAttribute="leading" id="znX-E7-5jo"/>
                     </constraints>
                 </customView>
             </subviews>
             <constraints>
+                <constraint firstItem="gRy-QW-fFD" firstAttribute="centerX" secondItem="c22-O7-iKe" secondAttribute="centerX" id="24Z-lu-lAK"/>
                 <constraint firstAttribute="bottom" secondItem="gRy-QW-fFD" secondAttribute="bottom" id="IfS-F9-Yzd"/>
                 <constraint firstItem="gRy-QW-fFD" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="eUO-5p-M52"/>
-                <constraint firstItem="gRy-QW-fFD" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="32" id="lQd-yy-Sbp"/>
-                <constraint firstAttribute="trailing" secondItem="gRy-QW-fFD" secondAttribute="trailing" constant="32" id="xXp-GB-sJP"/>
+                <constraint firstItem="gRy-QW-fFD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="c22-O7-iKe" secondAttribute="leading" id="lQd-yy-Sbp"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gRy-QW-fFD" secondAttribute="trailing" id="xXp-GB-sJP"/>
             </constraints>
             <point key="canvasLocation" x="101" y="-496"/>
         </customView>

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/GeneralPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/GeneralPane.xib
@@ -58,8 +58,8 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="54O-O0-p2M">
-                            <rect key="frame" x="95" y="51" width="192" height="18"/>
-                            <buttonCell key="cell" type="check" title="Display duplicated services" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stD-Gu-pED">
+                            <rect key="frame" x="95" y="51" width="181" height="18"/>
+                            <buttonCell key="cell" type="check" title="Show duplicated services" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="stD-Gu-pED">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -80,8 +80,8 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NU1-eW-0mB">
-                            <rect key="frame" x="95" y="147" width="184" height="18"/>
-                            <buttonCell key="cell" type="check" title="Display &quot;Reload&quot; on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tHP-Rs-wID">
+                            <rect key="frame" x="95" y="147" width="172" height="18"/>
+                            <buttonCell key="cell" type="check" title="Show “Reload” on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="tHP-Rs-wID">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>
@@ -100,8 +100,8 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E6F-8T-u6X">
-                            <rect key="frame" x="95" y="73" width="241" height="18"/>
-                            <buttonCell key="cell" type="check" title="Display &quot;Open Home.app&quot; on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0bf-nM-uXN">
+                            <rect key="frame" x="95" y="73" width="229" height="18"/>
+                            <buttonCell key="cell" type="check" title="Show “Open Home.app” on menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="0bf-nM-uXN">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
                             </buttonCell>

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/InformationPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/InformationPane.xib
@@ -14,23 +14,23 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="167"/>
+            <rect key="frame" x="0.0" y="0.0" width="600" height="122"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView id="tfe-Xy-SuX">
-                    <rect key="frame" x="103" y="0.0" width="394" height="167"/>
+                    <rect key="frame" x="159" y="0.0" width="282" height="122"/>
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                     <subviews>
-                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="cPs-wE-ze0">
-                            <rect key="frame" x="56" y="75" width="84" height="16"/>
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="cPs-wE-ze0">
+                            <rect key="frame" x="46" y="58" width="84" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Source code:" id="GRs-qi-tgr">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
                         </textField>
-                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="58S-j0-3mu">
-                            <rect key="frame" x="28" y="29" width="112" height="16"/>
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="58S-j0-3mu">
+                            <rect key="frame" x="18" y="30" width="112" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Acknowlegement:" id="Pvk-zR-jJh">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -38,7 +38,7 @@
                             </textFieldCell>
                         </textField>
                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="naR-Mu-Ig3">
-                            <rect key="frame" x="144" y="121" width="59" height="16"/>
+                            <rect key="frame" x="134" y="86" width="59" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="3.0 (100)" id="1OJ-qY-yUk">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -46,7 +46,7 @@
                             </textFieldCell>
                         </textField>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FIa-eD-JXT">
-                            <rect key="frame" x="139" y="66" width="139" height="32"/>
+                            <rect key="frame" x="129" y="48" width="139" height="32"/>
                             <buttonCell key="cell" type="push" title="Open github.com" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="XdS-KB-BdG">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -56,7 +56,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ISY-IM-5bV">
-                            <rect key="frame" x="139" y="20" width="103" height="32"/>
+                            <rect key="frame" x="129" y="20" width="103" height="32"/>
                             <buttonCell key="cell" type="push" title="Learn More" bezelStyle="rounded" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="e0K-az-LXZ">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -65,8 +65,8 @@
                                 <action selector="openAcknowledgementWithSender:" target="-2" id="wsg-AV-USx"/>
                             </connections>
                         </button>
-                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nxQ-YP-EPD">
-                            <rect key="frame" x="87" y="121" width="53" height="16"/>
+                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="nxQ-YP-EPD">
+                            <rect key="frame" x="77" y="86" width="53" height="16"/>
                             <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Version:" id="0xY-yl-ENL">
                                 <font key="font" usesAppearanceFont="YES"/>
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -76,27 +76,34 @@
                     </subviews>
                     <constraints>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ISY-IM-5bV" secondAttribute="trailing" constant="20" symbolic="YES" id="0l5-Pd-AXv"/>
-                        <constraint firstItem="nxQ-YP-EPD" firstAttribute="top" secondItem="tfe-Xy-SuX" secondAttribute="top" constant="30" id="4yx-QT-IAy"/>
-                        <constraint firstItem="58S-j0-3mu" firstAttribute="top" secondItem="cPs-wE-ze0" secondAttribute="bottom" constant="30" id="76O-eZ-XF6"/>
+                        <constraint firstItem="nxQ-YP-EPD" firstAttribute="top" secondItem="tfe-Xy-SuX" secondAttribute="top" constant="20" symbolic="YES" id="4yx-QT-IAy"/>
+                        <constraint firstItem="58S-j0-3mu" firstAttribute="top" secondItem="cPs-wE-ze0" secondAttribute="bottom" constant="12" id="76O-eZ-XF6"/>
                         <constraint firstItem="cPs-wE-ze0" firstAttribute="trailing" secondItem="nxQ-YP-EPD" secondAttribute="trailing" id="7cu-NP-9r3"/>
-                        <constraint firstItem="ISY-IM-5bV" firstAttribute="centerY" secondItem="58S-j0-3mu" secondAttribute="centerY" id="8zz-33-vtn"/>
+                        <constraint firstItem="ISY-IM-5bV" firstAttribute="firstBaseline" secondItem="58S-j0-3mu" secondAttribute="firstBaseline" id="8zz-33-vtn"/>
                         <constraint firstItem="FIa-eD-JXT" firstAttribute="leading" secondItem="cPs-wE-ze0" secondAttribute="trailing" constant="8" symbolic="YES" id="9EM-DY-uYs"/>
-                        <constraint firstItem="FIa-eD-JXT" firstAttribute="centerY" secondItem="cPs-wE-ze0" secondAttribute="centerY" id="Ka5-wO-A11"/>
+                        <constraint firstItem="FIa-eD-JXT" firstAttribute="firstBaseline" secondItem="cPs-wE-ze0" secondAttribute="firstBaseline" id="Ka5-wO-A11"/>
                         <constraint firstItem="ISY-IM-5bV" firstAttribute="leading" secondItem="58S-j0-3mu" secondAttribute="trailing" constant="8" symbolic="YES" id="N1k-Qn-uTN"/>
-                        <constraint firstItem="cPs-wE-ze0" firstAttribute="top" secondItem="nxQ-YP-EPD" secondAttribute="bottom" constant="30" id="OBh-11-9qt"/>
-                        <constraint firstItem="naR-Mu-Ig3" firstAttribute="centerY" secondItem="nxQ-YP-EPD" secondAttribute="centerY" id="dzQ-pw-hlD"/>
-                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FIa-eD-JXT" secondAttribute="trailing" constant="122" id="kcW-BK-bvd"/>
+                        <constraint firstItem="cPs-wE-ze0" firstAttribute="top" secondItem="nxQ-YP-EPD" secondAttribute="bottom" constant="12" id="OBh-11-9qt"/>
+                        <constraint firstItem="naR-Mu-Ig3" firstAttribute="firstBaseline" secondItem="nxQ-YP-EPD" secondAttribute="firstBaseline" id="dzQ-pw-hlD"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FIa-eD-JXT" secondAttribute="trailing" constant="20" symbolic="YES" id="kcW-BK-bvd"/>
                         <constraint firstItem="naR-Mu-Ig3" firstAttribute="leading" secondItem="nxQ-YP-EPD" secondAttribute="trailing" constant="8" symbolic="YES" id="nkV-nV-oVH"/>
                         <constraint firstItem="nxQ-YP-EPD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tfe-Xy-SuX" secondAttribute="leading" constant="20" symbolic="YES" id="ofH-J4-3OE"/>
-                        <constraint firstItem="cPs-wE-ze0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tfe-Xy-SuX" secondAttribute="leading" constant="30" id="sVA-I4-GHo"/>
+                        <constraint firstItem="cPs-wE-ze0" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tfe-Xy-SuX" secondAttribute="leading" constant="20" symbolic="YES" id="sVA-I4-GHo"/>
                         <constraint firstItem="58S-j0-3mu" firstAttribute="trailing" secondItem="cPs-wE-ze0" secondAttribute="trailing" id="t4g-sP-k4c"/>
-                        <constraint firstItem="58S-j0-3mu" firstAttribute="leading" secondItem="tfe-Xy-SuX" secondAttribute="leading" constant="30" id="yWi-Sy-IYz"/>
+                        <constraint firstItem="58S-j0-3mu" firstAttribute="leading" secondItem="tfe-Xy-SuX" secondAttribute="leading" constant="20" symbolic="YES" id="yWi-Sy-IYz"/>
                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="naR-Mu-Ig3" secondAttribute="trailing" constant="20" symbolic="YES" id="zfY-uz-gVI"/>
-                        <constraint firstAttribute="bottom" secondItem="58S-j0-3mu" secondAttribute="bottom" constant="29" id="zl5-8o-QBa"/>
+                        <constraint firstAttribute="bottom" secondItem="58S-j0-3mu" secondAttribute="bottom" constant="30" id="zl5-8o-QBa"/>
                     </constraints>
                 </customView>
             </subviews>
-            <point key="canvasLocation" x="118" y="76.5"/>
+            <constraints>
+                <constraint firstItem="tfe-Xy-SuX" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="3EJ-PU-CRg"/>
+                <constraint firstAttribute="bottom" secondItem="tfe-Xy-SuX" secondAttribute="bottom" id="Giw-1U-ho1"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tfe-Xy-SuX" secondAttribute="trailing" constant="20" symbolic="YES" id="kHt-tJ-mGd"/>
+                <constraint firstItem="tfe-Xy-SuX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="c22-O7-iKe" secondAttribute="leading" id="p4U-nU-3vp"/>
+                <constraint firstItem="tfe-Xy-SuX" firstAttribute="centerX" secondItem="c22-O7-iKe" secondAttribute="centerX" id="v2e-28-Xb0"/>
+            </constraints>
+            <point key="canvasLocation" x="135" y="102"/>
         </customView>
     </objects>
 </document>

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/ShortcutsPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/ShortcutsPane.xib
@@ -13,12 +13,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="c22-O7-iKe">
-            <rect key="frame" x="0.0" y="0.0" width="600" height="360"/>
+        <customView misplaced="YES" id="c22-O7-iKe">
+            <rect key="frame" x="0.0" y="0.0" width="600" height="370"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="JXN-L3-Ptt">
-                    <rect key="frame" x="20" y="20" width="560" height="320"/>
+                    <rect key="frame" x="20" y="30" width="560" height="320"/>
                     <view key="contentView" id="qmr-R8-yVo">
                         <rect key="frame" x="1" y="1" width="558" height="318"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -40,13 +40,13 @@
                                 </connections>
                             </button>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xg1-cf-gWD">
-                                <rect key="frame" x="0.0" y="24" width="558" height="266"/>
+                                <rect key="frame" x="0.0" y="24" width="558" height="182"/>
                                 <clipView key="contentView" id="S22-kk-7Fa">
-                                    <rect key="frame" x="1" y="1" width="556" height="264"/>
+                                    <rect key="frame" x="1" y="1" width="556" height="180"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" headerView="6Dt-0r-HGC" viewBased="YES" id="XvQ-8k-dq6">
-                                            <rect key="frame" x="0.0" y="0.0" width="556" height="236"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="556" height="152"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -127,7 +127,7 @@
                                     </subviews>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="8sF-Tj-qAj">
-                                    <rect key="frame" x="1" y="107" width="556" height="16"/>
+                                    <rect key="frame" x="1" y="249" width="556" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Jhu-mc-1KY">
@@ -162,7 +162,7 @@
             </subviews>
             <constraints>
                 <constraint firstItem="JXN-L3-Ptt" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="20" symbolic="YES" id="Hsb-T8-dSy"/>
-                <constraint firstAttribute="bottom" secondItem="JXN-L3-Ptt" secondAttribute="bottom" constant="20" symbolic="YES" id="pNg-e9-KM0"/>
+                <constraint firstAttribute="bottom" secondItem="JXN-L3-Ptt" secondAttribute="bottom" constant="30" id="pNg-e9-KM0"/>
                 <constraint firstAttribute="trailing" secondItem="JXN-L3-Ptt" secondAttribute="trailing" constant="20" symbolic="YES" id="u48-KT-oIk"/>
                 <constraint firstItem="JXN-L3-Ptt" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="20" symbolic="YES" id="yNc-qG-UFH"/>
             </constraints>

--- a/HomeConMenu/macOS/PreferencePanes/Base.lproj/ShortcutsPane.xib
+++ b/HomeConMenu/macOS/PreferencePanes/Base.lproj/ShortcutsPane.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" id="c22-O7-iKe">
+        <customView id="c22-O7-iKe">
             <rect key="frame" x="0.0" y="0.0" width="600" height="370"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
@@ -40,13 +40,13 @@
                                 </connections>
                             </button>
                             <scrollView autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xg1-cf-gWD">
-                                <rect key="frame" x="0.0" y="24" width="558" height="182"/>
+                                <rect key="frame" x="0.0" y="24" width="558" height="126"/>
                                 <clipView key="contentView" id="S22-kk-7Fa">
-                                    <rect key="frame" x="1" y="1" width="556" height="180"/>
+                                    <rect key="frame" x="1" y="1" width="556" height="124"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" multipleSelection="NO" autosaveColumns="NO" rowHeight="24" rowSizeStyle="automatic" headerView="6Dt-0r-HGC" viewBased="YES" id="XvQ-8k-dq6">
-                                            <rect key="frame" x="0.0" y="0.0" width="556" height="152"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="556" height="96"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="0.0"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -127,7 +127,7 @@
                                     </subviews>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="8sF-Tj-qAj">
-                                    <rect key="frame" x="1" y="249" width="556" height="16"/>
+                                    <rect key="frame" x="1" y="165" width="556" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Jhu-mc-1KY">
@@ -158,6 +158,7 @@
                     </constraints>
                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                     <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    <font key="titleFont" metaFont="smallSystem"/>
                 </box>
             </subviews>
             <constraints>

--- a/HomeConMenu/macOS/PreferencePanes/ShortcutsPaneController.swift
+++ b/HomeConMenu/macOS/PreferencePanes/ShortcutsPaneController.swift
@@ -85,15 +85,15 @@ class ShortcutsPaneController: NSViewController, NSTableViewDataSource, NSTableV
                     view.removeFromSuperview()
                 }
                 if let r = KeyboardShortcuts.Name(rawValue: shortcutLabels[row].uniqueIdentifier.uuidString) {
-                    let recoder = KeyboardShortcuts.RecorderCocoa(for: r)
-                    view.addSubview(recoder)
+                    let recorder = KeyboardShortcuts.RecorderCocoa(for: r)
+                    view.addSubview(recorder)
                     view.translatesAutoresizingMaskIntoConstraints = false
-                    recoder.translatesAutoresizingMaskIntoConstraints = false
-                    view.trailingAnchor.constraint(equalTo: recoder.trailingAnchor, constant: 0).isActive = true
-                    recoder.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0).isActive = true
-                    recoder.heightAnchor.constraint(equalToConstant: 20).isActive = true
-                    view.centerYAnchor.constraint(equalTo: recoder.centerYAnchor).isActive = true
-                    recoder.bezelStyle = .squareBezel
+                    recorder.translatesAutoresizingMaskIntoConstraints = false
+                    view.trailingAnchor.constraint(equalTo: recorder.trailingAnchor, constant: 0).isActive = true
+                    recorder.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0).isActive = true
+                    recorder.heightAnchor.constraint(equalToConstant: 20).isActive = true
+                    view.centerYAnchor.constraint(equalTo: recorder.centerYAnchor).isActive = true
+                    recorder.bezelStyle = .squareBezel
                 }
             }
             return view

--- a/HomeConMenu/macOS/PreferencePanes/ShortcutsPaneController.swift
+++ b/HomeConMenu/macOS/PreferencePanes/ShortcutsPaneController.swift
@@ -41,7 +41,7 @@ class ShortcutsPaneController: NSViewController, NSTableViewDataSource, NSTableV
         alert.informativeText = NSLocalizedString("You will remove all key bindings settings. Are you sure to remove them?", comment:"")
         alert.alertStyle = .critical
         
-        alert.addButton(withTitle: NSLocalizedString("Remove all", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("Remove All", comment: ""))
         alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
         
         let ret = alert.runModal()

--- a/HomeConMenu/macOS/PreferencePanes/mul.lproj/GeneralPane.xcstrings
+++ b/HomeConMenu/macOS/PreferencePanes/mul.lproj/GeneralPane.xcstrings
@@ -2,19 +2,19 @@
   "sourceLanguage" : "en",
   "strings" : {
     "0bf-nM-uXN.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Display \\\"Open Home.app\\\" on menu\"; ObjectID = \"0bf-nM-uXN\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Show “Open Home.app” on menu\"; ObjectID = \"0bf-nM-uXN\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Display \"Open Home.app\" on menu"
+            "value" : "Show “Open Home.app” on menu"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "\"ホームアプリを開く\"メニューを表示"
+            "value" : "“ホームアプリを開く”メニューを表示"
           }
         }
       }
@@ -128,13 +128,13 @@
       }
     },
     "stD-Gu-pED.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Display duplicated services\"; ObjectID = \"stD-Gu-pED\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Show duplicated services\"; ObjectID = \"stD-Gu-pED\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Display duplicated services"
+            "value" : "Show duplicated services"
           }
         },
         "ja" : {
@@ -146,13 +146,13 @@
       }
     },
     "tHP-Rs-wID.title" : {
-      "comment" : "Class = \"NSButtonCell\"; title = \"Display \\\"Reload\\\" on menu\"; ObjectID = \"tHP-Rs-wID\";",
+      "comment" : "Class = \"NSButtonCell\"; title = \"Show “Reload” on menu\"; ObjectID = \"tHP-Rs-wID\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Display \"Reload\" on menu"
+            "value" : "Show “Reload” on menu"
           }
         },
         "ja" : {

--- a/HomeConMenu/macOS/mul.lproj/LaunchView.xcstrings
+++ b/HomeConMenu/macOS/mul.lproj/LaunchView.xcstrings
@@ -92,19 +92,19 @@
       }
     },
     "wrg-Q9-ZTw.title" : {
-      "comment" : "Class = \"NSTextFieldCell\"; title = \"To use this application, go to Security & Privacy settings in System Preferences and allow HomeConMenu to access HomeKit.\"; ObjectID = \"wrg-Q9-ZTw\";",
+      "comment" : "Class = \"NSTextFieldCell\"; title = \"To use this application, go to Security & Privacy settings in System Settings and allow HomeConMenu to access HomeKit.\"; ObjectID = \"wrg-Q9-ZTw\";",
       "extractionState" : "extracted_with_value",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "To use this application, go to Security & Privacy settings in System Preferences and allow HomeConMenu to access HomeKit."
+            "value" : "To use this application, go to Security & Privacy settings in System Settings and allow HomeConMenu to access HomeKit."
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "HomeConMenuでホームデバイスを制御するにはHomeKitへのアクセス権が必要です。システム環境設定の「セキュリティとプライバシー」からHomeConMenuにアクセス権を設定してください。"
+            "value" : "HomeConMenuでホームデバイスを制御するにはHomeKitへのアクセス権が必要です。システム設定の「セキュリティとプライバシー」からHomeConMenuにアクセス権を設定してください。"
           }
         }
       }


### PR DESCRIPTION
Hi, I've just modified the UI mainly for the Settings window to make the app more macOS native. I included several updates together in this PR. let me know if you want to separate them so that you can adopt a part of my PR.

In this PR, I modified:

1. Fix a typo in the code (though it has no impact on the app).
2. Replace the term "Preferences" with "Settings."
3. Improve the autolayout in the storyboards for settings panes to make the panes more native.
4. Some terminology to use more Apple-favored expressions.
    - Use "Show" instead of "Display."
    - Use curly quotations instead of straight ones.
    - Use the title case instead of the sentence case for buttons.

In addition, I found the Japanese localization in the Donate settings pane inconsistent among donation types. However, since I could not find a way to fix it in the project, I just pointed it out here.
(Moreover, I personally feel the font size in this pane is too large, but as there are no guidelines for this kind of view, it's up to you.)

<img width="712" alt="Screenshot 2023-11-11 at 22 36 26" src="https://github.com/sonsongithub/HomeConMenu/assets/1165044/0a912562-41b3-4130-90a2-75796a8fe8c6">
