### PR TITLE
Fix using keyboard shortcuts when in a full-screen app

### DIFF
--- a/HomeConMenu/macOS/MacOSController.swift
+++ b/HomeConMenu/macOS/MacOSController.swift
@@ -50,6 +50,19 @@ class MacOSController: NSObject, iOS2Mac, NSMenuDelegate {
         NotificationCenter.default.addObserver(self, selector: #selector(self.didChangeUserDefaults), name: UserDefaults.didChangeNotification, object: nil)
         // NSWorkspace.shared.notificationCenter.addObserver(self, selector: #selector(self.didAwakeSleep), name: NSWorkspace.didWakeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(self.windowWillClose(notification:)), name: NSWindow.willCloseNotification, object: nil)
+		
+		// Create invisible window that's always on-screen
+		// Allows using keyboard shortcuts even when menubar is hidden
+		let alwaysPresentWindow = NSWindow()
+		alwaysPresentWindow.styleMask = [.borderless]
+		alwaysPresentWindow.collectionBehavior = [
+			.canJoinAllSpaces,
+			.fullScreenAuxiliary,
+			.ignoresCycle,
+			.transient
+		]
+		alwaysPresentWindow.setFrame(.zero, display: true)
+		alwaysPresentWindow.orderFront(self)
     }
     
     /// Collect and returns a collection of ShortcutInfo that is fetched from HomeKit.


### PR DESCRIPTION
Third-party apps can only control HomeKit when they're “in the foreground”. On macOS, this just means having a piece of UI visible, such as the menubar icon. As a result, when an app is in full-screen mode, HomeConMenu keyboard shortcuts stop working.

This PR creates an ever-present invisible window, which fixes the issue.