### PR TITLE
Improve value formatting

### DIFF
--- a/HomeConMenu/macOS/MenuItem/SensorMenuItem.swift
+++ b/HomeConMenu/macOS/MenuItem/SensorMenuItem.swift
@@ -79,7 +79,8 @@ class SensorMenuItem: NSMenuItem, MenuItemFromUUID, ErrorMenuItem, MenuItemOrder
         reachable = true
         switch (self.type, value) {
         case (.temperature, let value):
-            self.title = "\(value)℃"
+			let temperatureMeasurement = Measurement(value: value, unit: UnitTemperature.celsius)
+			self.title = "\(MeasurementFormatter().string(from: temperatureMeasurement))"
         case (.humidity, let value):
             self.title = "\(value.formatted(.number.precision(.fractionLength(0...1))))%"
         default:

--- a/HomeConMenu/macOS/MenuItem/SensorMenuItem.swift
+++ b/HomeConMenu/macOS/MenuItem/SensorMenuItem.swift
@@ -81,7 +81,7 @@ class SensorMenuItem: NSMenuItem, MenuItemFromUUID, ErrorMenuItem, MenuItemOrder
         case (.temperature, let value):
             self.title = "\(value)℃"
         case (.humidity, let value):
-            self.title = "\(value)%"
+            self.title = "\(value.formatted(.number.precision(.fractionLength(0...1))))%"
         default:
             self.title = "unsupported"
         }


### PR DESCRIPTION
This PR improves the display of temperature and humidity values:
- Temperature is now formatted according to the user's locale (in either Celsius or Fahrenheit, respecting the decimals separator, etc)
- The humidity now has one significant fraction digit at most

Before:
![22.299999237060547°C](https://github.com/sonsongithub/HomeConMenu/assets/2979318/fb6c5adc-7085-4050-8e14-74c1b51abccc)

After, for a Celsius user:
![22,3°C](https://github.com/sonsongithub/HomeConMenu/assets/2979318/0904d40a-e61e-44d5-8418-47babfb16686)

After, for a Fahrenheit user:
![72.14°F](https://github.com/sonsongithub/HomeConMenu/assets/2979318/304ecb68-e020-4a47-82e4-45b1e8448730)
